### PR TITLE
Ica aroma fix #30

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
-FROM python:3.6-alpine
+FROM continuumio/miniconda3
+RUN apt-get update
+RUN apt-get install gcc -y
+RUN pip install fmridenoise
 ADD . /fmridenoise
 WORKDIR /fmridenoise
+ENTRYPOINT /bin/sh
+

--- a/fmridenoise/__main__.py
+++ b/fmridenoise/__main__.py
@@ -92,7 +92,7 @@ def parse_pipelines(pipelines_args: str or set = "all", use_aroma=False) -> set:
         if pipelines_args != "all":
             raise ValueError("Only valid string argument is 'all'")
         elif pipelines_args == 'all' and use_aroma == False: 
-            return set([p for p in get_pipelines_names() if 'ICA-AROMA' not in p])
+            return set([p for p in get_pipelines_paths() if 'ICA-AROMA' not in p])
         else:
             return get_pipelines_paths()
     known_pipelines = get_pipelines_names()

--- a/fmridenoise/__main__.py
+++ b/fmridenoise/__main__.py
@@ -54,6 +54,10 @@ def get_parser() -> argparse.ArgumentParser:
                         type=float,
                         default=LOW_PASS_DEFAULT,
                         help=f"Low pass filter value, default {LOW_PASS_DEFAULT}")
+    parser.add_argument("--use-aroma",
+                        help="Skip ICA-AROMA pipelines, default False",
+                        action="store_true",
+                        default=False)
     parser.add_argument("--MultiProc",
                         help="Run script on multiple processors, default False",
                         action="store_true",
@@ -75,7 +79,7 @@ def get_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def parse_pipelines(pipelines_args: str or set = "all") -> set:
+def parse_pipelines(pipelines_args: str or set = "all", use_aroma=False) -> set:
     """
     Parses all possible pipeline options:
     :param pipelines_args: set or str, only valid string argument is 'all'.
@@ -87,6 +91,8 @@ def parse_pipelines(pipelines_args: str or set = "all") -> set:
     if type(pipelines_args) is str:
         if pipelines_args != "all":
             raise ValueError("Only valid string argument is 'all'")
+        elif pipelines_args == 'all' and use_aroma == False: 
+            return set([p for p in get_pipelines_names() if 'ICA-AROMA' not in p])
         else:
             return get_pipelines_paths()
     known_pipelines = get_pipelines_names()
@@ -136,7 +142,7 @@ def main() -> None:
     derivatives = args.derivatives if type(args.derivatives) in (list, bool) else [args.derivatives]
     derivatives = list(map(lambda x: join(input_dir, 'derivatives', x), derivatives))
     # pipelines
-    pipelines = parse_pipelines(args.pipelines)
+    pipelines = parse_pipelines(args.pipelines, args.use_aroma)
     # creating workflow
     workflow = init_fmridenoise_wf(input_dir, 
                                    derivatives=derivatives,
@@ -145,7 +151,8 @@ def main() -> None:
                                    task=args.tasks,
                                    pipelines_paths=pipelines,
                                    high_pass=args.high_pass,
-                                   low_pass=args.low_pass)
+                                   low_pass=args.low_pass,
+                                   ica_aroma=args.use_aroma)
     # creating graph from workflow
     if args.graph is not None:
         try:  # TODO: Look for pydot/dot and add to requirements

--- a/tests/misc/test_parser.py
+++ b/tests/misc/test_parser.py
@@ -7,10 +7,15 @@ class TestPipelinesParser(ut.TestCase):
 
     pipelines_dir = dirname(pipe.__file__)
     all_pipelines_valid = set(glob(join(pipelines_dir, "*.json")))
+    noicaaroma_pipelines_valid = set([p for p in all_pipelines_valid if 'ICA-AROMA' not in p])
 
     def test_parse_pipelines_without_custom(self):
-        paths = parse_pipelines("all")
+        paths = parse_pipelines("all", True)
         self.assertSetEqual(self.all_pipelines_valid, paths)
+
+    def test_parse_pipelines_without_custom_noicaaroma(self):
+        paths = parse_pipelines("all", False)
+        self.assertSetEqual(self.noicaaroma_pipelines_valid, paths)
 
     def test_parse_pipelines_custom(self):
         custom = {join(dirname(__file__), "custom_pipeline.json")}


### PR DESCRIPTION
I was still getting an "ICA-Aroma file not found" error with the current fix outlined in #30. Because the following lines of code in interfaces/denooising.py was still running: 

```
        if pipeline_aroma:
            if not self.inputs.fmri_prep_aroma:
                raise ValueError("No ICA-AROMA files found")
```

This fix adds the following lines to parse_pipeline function entails that ICA-AROMA pipelines are excluded from the entire analysis.

```
        elif pipelines_args == 'all' and use_aroma == False: 
            return set([p for p in get_pipelines_paths() if 'ICA-AROMA' not in p])
```

This solved my issue at least. Hope it helps!

