### PR TITLE
Fix for /tmp/ being used when -w is set

### DIFF
--- a/fmridenoise/interfaces/denoising.py
+++ b/fmridenoise/interfaces/denoising.py
@@ -60,6 +60,11 @@ class DenoiseInputSpec(BaseInterfaceInputSpec):
         desc="Low-pass filter"
     )
 
+    ica_aroma = traits.Bool(
+        mandatory=False,
+        desc='ICA-Aroma files exists'
+    )
+
     smoothing = traits.Bool(
         mandatory=False,
         desc='Optional smoothing'
@@ -84,7 +89,6 @@ class Denoise(SimpleInterface):
         pipeline_name = self.inputs.pipeline['name']
         pipeline_aroma = self.inputs.pipeline['aroma']
         img = nb.load(self.inputs.fmri_prep)
-
         if pipeline_aroma:
             if not self.inputs.fmri_prep_aroma:
                 raise ValueError("No ICA-AROMA files found")
@@ -109,7 +113,6 @@ class Denoise(SimpleInterface):
             tr = self.inputs.tr_dict[task]
         else:
             raise KeyError(f'{task} TR not found in tr_dict')
-
 
         if smoothing and not pipeline_aroma:
            img = smooth_img(img, fwhm=6)

--- a/fmridenoise/utils/temps.py
+++ b/fmridenoise/utils/temps.py
@@ -10,7 +10,8 @@ base_dir = '/tmp'
 def mkdtemp(name: str) -> str:
     global temp_dirs
     try:
-        os.makedirs(name, exist_ok=True) # May be unsafe?
+        ret = name
+        os.makedirs(ret, exist_ok=True) # May be unsafe?
     except OSError:
         ret = tempfile.mkdtemp()
     temp_dirs.append(ret)

--- a/fmridenoise/utils/temps.py
+++ b/fmridenoise/utils/temps.py
@@ -10,8 +10,7 @@ base_dir = '/tmp'
 def mkdtemp(name: str) -> str:
     global temp_dirs
     try:
-        ret = os.path.join(name)
-        os.makedirs(ret, exist_ok=True) # May be unsafe?
+        os.makedirs(name, exist_ok=True) # May be unsafe?
     except OSError:
         ret = tempfile.mkdtemp()
     temp_dirs.append(ret)

--- a/fmridenoise/utils/temps.py
+++ b/fmridenoise/utils/temps.py
@@ -10,7 +10,7 @@ base_dir = '/tmp'
 def mkdtemp(name: str) -> str:
     global temp_dirs
     try:
-        ret = os.path.join('/tmp/fmridenoise/' + name)
+        ret = os.path.join(name)
         os.makedirs(ret, exist_ok=True) # May be unsafe?
     except OSError:
         ret = tempfile.mkdtemp()

--- a/fmridenoise/workflows/base.py
+++ b/fmridenoise/workflows/base.py
@@ -67,9 +67,10 @@ def init_fmridenoise_wf(bids_dir,
     # 3) --- Confounds preprocessing
 
     # Inputs: pipeline, conf_raw, conf_json
+    temppath = os.path.join(base_dir, 'prep_conf')
     prep_conf = pe.MapNode(
         Confounds(
-            output_dir=temps.mkdtemp(base_dir + 'prep_conf')
+            output_dir=temps.mkdtemp(temppath)
         ),
         iterfield=['conf_raw', 'conf_json', 'entities'],
         name="ConfPrep")
@@ -84,13 +85,14 @@ def init_fmridenoise_wf(bids_dir,
     else:
         iterate.append('fmri_prep_aroma')
 
+    temppath = os.path.join(base_dir, 'denoise')
     denoise = pe.MapNode(
         Denoise(
             smoothing=smoothing,
             high_pass=high_pass,
             low_pass=low_pass,
             ica_aroma=ica_aroma,
-            output_dir=temps.mkdtemp(base_dir + 'denoise')
+            output_dir=temps.mkdtemp(temppath)
         ),
         iterfield=iterate,
         name="Denoiser", mem_gb=6)
@@ -99,10 +101,11 @@ def init_fmridenoise_wf(bids_dir,
     # 5) --- Connectivity estimation
 
     # Inputs: fmri_denoised
+    temppath = os.path.join(base_dir, 'connectivity')
     parcellation_path = get_parcelation_file_path()
     connectivity = pe.MapNode(
         Connectivity(
-            output_dir=temps.mkdtemp(base_dir + 'connectivity'),
+            output_dir=temps.mkdtemp(temppath),
             parcellation=parcellation_path
         ),
         iterfield=['fmri_denoised'],

--- a/fmridenoise/workflows/base.py
+++ b/fmridenoise/workflows/base.py
@@ -35,7 +35,7 @@ def init_fmridenoise_wf(bids_dir,
                         low_pass=0.08,
                         # desc=None,
                         # ignore=None, force_index=None,
-                        base_dir='/tmp/fmridenoise', name='fmridenoise_wf'
+                        base_dir='/tmp/fmridenoise/', name='fmridenoise_wf'
                         ):
     workflow = pe.Workflow(name=name, base_dir=base_dir)
     temps.base_dir = base_dir
@@ -69,7 +69,7 @@ def init_fmridenoise_wf(bids_dir,
     # Inputs: pipeline, conf_raw, conf_json
     prep_conf = pe.MapNode(
         Confounds(
-            output_dir=temps.mkdtemp('prep_conf')
+            output_dir=temps.mkdtemp(base_dir + 'prep_conf')
         ),
         iterfield=['conf_raw', 'conf_json', 'entities'],
         name="ConfPrep")
@@ -90,7 +90,7 @@ def init_fmridenoise_wf(bids_dir,
             high_pass=high_pass,
             low_pass=low_pass,
             ica_aroma=ica_aroma,
-            output_dir=temps.mkdtemp('denoise')
+            output_dir=temps.mkdtemp(base_dir + 'denoise')
         ),
         iterfield=iterate,
         name="Denoiser", mem_gb=6)
@@ -102,7 +102,7 @@ def init_fmridenoise_wf(bids_dir,
     parcellation_path = get_parcelation_file_path()
     connectivity = pe.MapNode(
         Connectivity(
-            output_dir=temps.mkdtemp('connectivity'),
+            output_dir=temps.mkdtemp(base_dir + 'connectivity'),
             parcellation=parcellation_path
         ),
         iterfield=['fmri_denoised'],


### PR DESCRIPTION
#40 Potential fix to problem number 2 (currently testing, the changes need to be made regardless). But these needed to be fixed from last merge regarding working directory. 

The three instances in base.py were creating pre_conf, denoise, and connectivity directories in /tmp/fmridenoise/ and that have been creating the problem I was facing where /tmp/ was still partially being used. 

I've also had to change utils/temps to make the argument `name` be the entire path, not `/tmp/fmridenoise/<name>`  (that was the problem)

(Don't merge yet! 2 changes need to be made)